### PR TITLE
[ACADEMIC-16169] [ACADEMIC-16182] Added Unit Tests to block.py

### DIFF
--- a/.annotation_safe_list.yml
+++ b/.annotation_safe_list.yml
@@ -1,0 +1,19 @@
+# This is a Code Annotations automatically-generated Django model safelist file.
+# These models must be annotated as follows in order to be counted in the coverage report.
+# See https://code-annotations.readthedocs.io/en/latest/safelist.html for more information.
+#
+# fake_app_1.FakeModelName:
+#    ".. no_pii:": "This model has no PII"
+# fake_app_2.FakeModel2:
+#    ".. choice_annotation:": foo, bar, baz
+
+admin.LogEntry:
+  ".. no_pii::": "This model has no PII"
+auth.Group:
+  ".. no_pii::": "This model has no PII"
+auth.Permission:
+  ".. no_pii::": "This model has no PII"
+auth.User:
+  ".. no_pii::": "This model has no PII"
+contenttypes.ContentType:
+  ".. no_pii::": "This model has no PII"

--- a/.pii_annotations.yml
+++ b/.pii_annotations.yml
@@ -1,0 +1,15 @@
+source_path: ./
+report_path: pii_report
+safelist_path: .annotation_safe_list.yml
+coverage_target: 100.0
+annotations:
+    ".. no_pii::":
+    "pii_group":
+        - ".. pii::":
+        - ".. pii_types::":
+            choices: [id, name, other]
+        - ".. pii_retirement::":
+            choices: [retained, local_api, consumer_api, third_party]
+extensions:
+    python:
+        - py

--- a/ai_aside/summaryhook_aside/text_utils.py
+++ b/ai_aside/summaryhook_aside/text_utils.py
@@ -1,0 +1,54 @@
+"""
+Text manipulation utils.
+"""
+
+from html.parser import HTMLParser
+from re import sub
+
+
+def cleanup_text(text):
+    """
+    Removes litter from replacing or manipulating text
+    """
+    stripped = sub(r'[^\S\r\n]+', ' ', text)  # Removing extra spaces
+    stripped = sub(r'\n{2,}', '\n', stripped)  # Removing extra new lines
+    stripped = sub(r'(\s+)?\n(\s+)?', '\n', stripped)  # Removing starting extra spacesbetween new lines
+    stripped = sub(r'(^(\s+)\n?)|(\n(\s+)?$)', '', stripped)  # Trim
+
+    return stripped
+
+
+class _HTMLToTextHelper(HTMLParser):  # lint-amnesty, pylint: disable=abstract-method
+    """
+    Helper function for html_to_text below
+    """
+
+    def __init__(self):
+        HTMLParser.__init__(self)
+        self.reset()
+        self.fed = []
+
+    def handle_data(self, data):
+        """takes the data in separate chunks"""
+        self.fed.append(data)
+
+    def handle_entityref(self, name):
+        """appends the reference to the body"""
+        self.fed.append('&%s;' % name)
+
+    def get_data(self):
+        """joins together the seperate chunks into one cohesive string"""
+        return ''.join(self.fed)
+
+
+def html_to_text(html):
+    """
+    Strips the html tags off of the text to return plaintext
+    """
+
+    htmlstripper = _HTMLToTextHelper()
+    htmlstripper.feed(html)
+    text = htmlstripper.get_data()
+    text = cleanup_text(text)
+
+    return text

--- a/manage.py
+++ b/manage.py
@@ -18,7 +18,7 @@ if __name__ == '__main__':
         # issue is really that Django is missing to avoid masking other
         # exceptions on Python 2.
         try:
-            import django  # pylint: disable=unused-import, wrong-import-position
+            import django  # pylint: disable=unused-import
         except ImportError as import_error:
             raise ImportError(
                 "Couldn't import Django. Are you sure it's installed and "

--- a/tests/summaryhook_aside/test_block.py
+++ b/tests/summaryhook_aside/test_block.py
@@ -1,0 +1,110 @@
+import unittest
+from datetime import datetime
+from unittest.mock import MagicMock, patch
+
+from ai_aside.summaryhook_aside.block import _extract_child_contents, _format_date, _get_children_contents
+
+
+class FakeTranscript():
+    def convert(transcript, format, output):
+        return 'This is the text version from the transcript'
+
+
+def fake_get_transcript(child):
+    return ['This is a transcript']
+
+
+class FakeChild:
+    transcript_download_format = 'txt'
+
+    def __init__(self, category, test_id='test-id'):
+        self.category = category
+        self.published_on = 'published-on-{}'.format(test_id)
+        self.edited_on = 'edited-on-{}'.format(test_id)
+        self.scope_ids = lambda: None
+        self.scope_ids.def_id = 'def-id-{}'.format(test_id)
+
+    def get_html(self):
+        if self.category == 'html':
+            return '<div>This is a test</div>'
+
+        return None
+
+
+class FakeBlock:
+    def __init__(self, children):
+        self.children = children
+
+    def get_children(self):
+        return self.children
+
+
+class TestSummaryHookAside(unittest.TestCase):
+    def setUp(self):
+        module_mock = MagicMock()
+        module_mock.Transcript = FakeTranscript
+        module_mock.get_transcript = fake_get_transcript
+        modules = {'xmodule.video_block.transcripts_utils': module_mock}
+        patch.dict('sys.modules', modules).start()
+
+    def test_format_date(self):
+        date = datetime(2023, 5, 1, 12, 0, 0)
+        formatted_date = _format_date(date)
+        self.assertEqual(formatted_date, '2023-05-01 12:00:00')
+
+    def test_format_date_with_invalid_input(self):
+        invalid_date = '2023-05-01'
+        formatted_date = _format_date(invalid_date)
+        self.assertIsNone(formatted_date)
+
+    def test_extract_child_contents_with_html(self):
+        category = 'html'
+
+        child = FakeChild(category)
+        content = _extract_child_contents(child, category)
+
+        self.assertEqual(content, 'This is a test')
+
+    def test_extract_child_contents_with_video(self):
+        category = 'video'
+
+        child = FakeChild(category)
+        content = _extract_child_contents(child, category)
+        self.assertEqual(content, 'This is the text version from the transcript')
+
+    def test_extract_child_contents_with_invalid_category(self):
+        category = 'invalid'
+
+        child = FakeChild(category)
+        content = _extract_child_contents(child, category)
+        self.assertIsNone(content)
+
+    def test_get_children_contents_with_valid_children(self):
+        children = [
+            FakeChild('html', '01'),
+            FakeChild('video', '02'),
+            FakeChild('unknown', '03'),
+        ]
+        block = FakeBlock(children)
+
+        expected = [{
+            'definition_id': 'def-id-01',
+            'type': 'html',
+            'text': 'This is a test',
+            'published_on': 'published-on-01',
+            'edited_on': 'edited-on-01',
+        }, {
+            'definition_id': 'def-id-02',
+            'type': 'video',
+            'text': 'This is the text version from the transcript',
+            'published_on': 'published-on-02',
+            'edited_on': 'edited-on-02',
+        }]
+
+        content = _get_children_contents(block)
+
+        self.assertEqual(content, expected)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/summaryhook_aside/test_text_utils.py
+++ b/tests/summaryhook_aside/test_text_utils.py
@@ -1,0 +1,55 @@
+import unittest
+from textwrap import dedent
+
+from ai_aside.summaryhook_aside.text_utils import html_to_text
+
+
+class TestSummaryHookAside(unittest.TestCase):
+    def test_html_to_text(self):
+        html_content = '''\
+            <div>
+                <h1>Lorem Ipsum</h1>
+                <p>Lorem ipsum dolor <em style="font-size: 99pt;">sit amet</em>, consectetur adipiscing elit.</p>
+                <!-- The next paragraph will have an intentional mismatching close tag -->
+                <p>Sed volutpat velit sed dui <i class="something">fringilla</i> fermentum.</div>
+                <p>Nullam quis velit at turpis lacinia convallis.</p>
+            </div>'''
+        expected_text = dedent('''\
+            Lorem Ipsum
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+            Sed volutpat velit sed dui fringilla fermentum.
+            Nullam quis velit at turpis lacinia convallis.''')
+        text = html_to_text(html_content)
+        self.assertEqual(text, expected_text)
+
+    def test_html_to_text_messy(self):
+        html_content = '''\
+            <custom>
+                <mismatching>Lorem Ipsum</tags>
+                > Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
+                > Sed volutpat velit sed dui fringilla fermentum.</42>
+                <p>> Nullam quis velit at turpis lacinia convallis.</p>'''
+        expected_text = dedent('''\
+            Lorem Ipsum
+            > Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+            > Sed volutpat velit sed dui fringilla fermentum.
+            > Nullam quis velit at turpis lacinia convallis.''')
+        text = html_to_text(html_content)
+        self.assertEqual(text, expected_text)
+
+    def test_html_to_text_iframe(self):
+        html_content = '''\
+            <iframe
+                src="https://mitx.qualtrics.com/jfe/form/SV_8ocnXlmaDwMRFgF?user_id=%%USER_ID%%"
+                height="1200"
+                width="100%"
+                title="Nothing useful can be parsed from this, maybe fetching the src in the future?"
+            ></iframe>
+            '''
+        expected_text = dedent('')
+        text = html_to_text(html_content)
+        self.assertEqual(text, expected_text)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
# [ACADEMIC-16169](https://jira.2u.com/browse/ACADEMIC-16169)
# [ACADEMIC-16182](https://jira.2u.com/browse/ACADEMIC-16182)

Updated the code to hace a simpler filtering on the potential summarizable content (check before actually processing).
Added unit tests to the repo (it wasn't set up) and added some coverage to simple methods for the `block.py` moude. We have some hacky imports on some modules we use that we can import due to the scope the code is running but not actually adding the dependency.

Minor cleanup on a few lines.