### PR TITLE
build(deps): bump actions/setup-python from 2 to 4 (CI Update Test)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,9 @@ on:
 jobs:
   testing:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write # need this for OIDC
+      contents: read
     strategy:
       matrix:
         tox-env: [django32, quality]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
         tox-env: [django32, quality]
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
         with:
           python-version: '3.8'
           architecture: x64

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
       - name: setup python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: 3.8
 

--- a/.github/workflows/test_publish.yml
+++ b/.github/workflows/test_publish.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
         with:
           python-version: '3.8'
           architecture: x64


### PR DESCRIPTION
This is a test branching from `rijuma/ACADEMIC-16218-ci-actions-fix` to test if this fixes the CI issue.