### PR TITLE
[ACADEMIC-16218] Updated permissions so the CI can run properly.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,9 @@ on:
 jobs:
   testing:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write # need this for OIDC
+      contents: read
     strategy:
       matrix:
         tox-env: [django32, quality]


### PR DESCRIPTION
Updated the permissions on `.github/workflows/ci.yml` accordingly for the CI actions to work.

Based on [this guide from Github's article](https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/about-security-hardening-with-openid-connect#adding-permissions-settings) that was pointed out in the error description itself.
