### PR TITLE
Ashultz0/open up handler

### DIFF
--- a/ai_aside/summaryhook_aside/block.py
+++ b/ai_aside/summaryhook_aside/block.py
@@ -179,13 +179,17 @@ class SummaryHookAside(XBlockAside):
         if not _children_have_summarizable_content(block):
             return fragment
 
+        # thirdparty=true connects to the unauthenticated handler for now,
+        # we will secure it in ACADEMIC-16187
+        handler_url = self.runtime.handler_url(self, 'summary_handler', thirdparty=True)
+
         fragment.add_content(
             _render_summary(
                 {
                     'data_url_api': settings.SUMMARY_HOOK_HOST,
                     'data_course_id': block.scope_ids.usage_id.course_key,
                     'data_content_id': block.scope_ids.usage_id,
-                    'data_handler_url': self.runtime.handler_url(self, 'summary_handler'),
+                    'data_handler_url': handler_url,
                     'js_url': settings.SUMMARY_HOOK_HOST + settings.SUMMARY_HOOK_JS_PATH,
                 }
             )


### PR DESCRIPTION
This changes the generated URL from one like this:

/courses/course-v1:edX+DemoX+Demo_Course/xblock/aside-usage-v2:block-v1$:edX+DemoX+Demo_Course+type@vertical+block@867dddb6f55d410caaa9c1eb9c6743ec::summaryhook_aside/handler/summary_handler

to one like this:

http://localhost:18000/courses/course-v1:edX+DemoX+Demo_Course/xblock/aside-usage-v2:block-v1$:edX+DemoX+Demo_Course+type@vertical+block@867dddb6f55d410caaa9c1eb9c6743ec::summaryhook_aside/handler_noauth/summary_handler 

We will secure it in a later ticket, this helps testing for the moment.

Note that the resulting URL is still not good enough for devstack, we will need some other trick, probably a local setting that gets injected into this URL to replace localhost with lms.

**Merge checklist:**
Check off if complete *or* not applicable:
- [x] Version bumped
- [x] Changelog record added
- [x] Documentation updated (not only docstrings)
- [x] Fixup commits are squashed away
- [x] Unit tests added/updated
- [x] Manual testing instructions provided
- [x] Noted any: Concerns, dependencies, migration issues, deadlines, tickets
