### PR TITLE
feat: enable replacing the lms name that aispot will be given

### DIFF
--- a/ai_aside/summaryhook_aside/block.py
+++ b/ai_aside/summaryhook_aside/block.py
@@ -183,6 +183,11 @@ class SummaryHookAside(XBlockAside):
         # we will secure it in ACADEMIC-16187
         handler_url = self.runtime.handler_url(self, 'summary_handler', thirdparty=True)
 
+        # enable ai-spot to see the LMS when they are installed together in devstack
+        aispot_lms_name = settings.AISPOT_LMS_NAME
+        if aispot_lms_name != '':
+            handler_url = handler_url.replace('localhost', aispot_lms_name)
+
         fragment.add_content(
             _render_summary(
                 {

--- a/ai_aside/summaryhook_aside/settings/common.py
+++ b/ai_aside/summaryhook_aside/settings/common.py
@@ -8,3 +8,4 @@ def plugin_settings(settings):
     env_tokens = getattr(settings, 'ENV_TOKENS', {})
     settings.SUMMARY_HOOK_HOST = env_tokens.get('SUMMARY_HOOK_HOST', '')
     settings.SUMMARY_HOOK_JS_PATH = env_tokens.get('SUMMARY_HOOK_JS_PATH', '')
+    settings.AISPOT_LMS_NAME = env_tokens.get('AISPOT_LMS_NAME', '')

--- a/ai_aside/summaryhook_aside/settings/devstack.py
+++ b/ai_aside/summaryhook_aside/settings/devstack.py
@@ -6,9 +6,10 @@ from os.path import abspath, dirname, join
 
 def plugin_settings(settings):
     """ Override/set summary hook devstack settings"""
-    settings.SUMMARY_HOOK_HOST = 'http://localhost:3000'
+    settings.SUMMARY_HOOK_HOST = 'http://ai-spot.2u.localhost'
     settings.SUMMARY_HOOK_JS_PATH = '/static/js/main.js'
     settings.SUMMARY_HOOK_MIN_SIZE = 500
+    settings.AISPOT_LMS_NAME = 'lms'  # in docker ai-spot sees the LMS as 'lms' not 'localhost'
     if os.path.isfile(join(dirname(abspath(__file__)), 'private.py')):
         from .private import plugin_settings_override  # pylint: disable=import-outside-toplevel,import-error
         plugin_settings_override(settings)


### PR DESCRIPTION
This lets us handle devstack, where the lms will be visible from the aispot container at "lms" but not at "localhost". Excatly what that name is depends on docker setup.

Production is not expected to use this setting since the aside should be able to generate a perfectly usable URL in that case.


**Merge checklist:**
Check off if complete *or* not applicable:
- [x] Version bumped
- [x] Changelog record added
- [x] Documentation updated (not only docstrings)
- [x] Fixup commits are squashed away
- [x] Unit tests added/updated
- [x] Manual testing instructions provided
- [x] Noted any: Concerns, dependencies, migration issues, deadlines, tickets
