### PR TITLE
fix content message field details

### DIFF
--- a/ai_aside/summaryhook_aside/block.py
+++ b/ai_aside/summaryhook_aside/block.py
@@ -13,6 +13,12 @@ from xblock.core import XBlock, XBlockAside
 from ai_aside.summaryhook_aside.text_utils import html_to_text
 from ai_aside.summaryhook_aside.waffle import summary_enabled, summary_staff_only
 
+# map block types to what ai-spot expects for content types
+CATEGORY_TYPE_MAP = {
+    "html": "TEXT",
+    "video": "VIDEO",
+}
+
 summary_fragment = """
 <div>&nbsp;</div>
 <div class="summary-hook">
@@ -82,6 +88,7 @@ def _get_children_contents(block):
     children = block.get_children()
     for child in children:
         category = getattr(child, 'category', None)
+        category_type = CATEGORY_TYPE_MAP.get(category)
         published_on = getattr(child, 'published_on', None)
         edited_on = getattr(child, 'edited_on', None)
         definition_id = str(getattr(getattr(child, 'scope_ids', None), 'def_id', None))
@@ -93,7 +100,7 @@ def _get_children_contents(block):
 
         content_fragments.append({
             'definition_id': definition_id,
-            'type': category,
+            'type': category_type,
             'text': text,
             'published_on': published_on,
             'edited_on': edited_on,

--- a/ai_aside/summaryhook_aside/block.py
+++ b/ai_aside/summaryhook_aside/block.py
@@ -100,8 +100,8 @@ def _get_children_contents(block):
 
         content_fragments.append({
             'definition_id': definition_id,
-            'type': category_type,
-            'text': text,
+            'content_type': category_type,
+            'content_text': text,
             'published_on': published_on,
             'edited_on': edited_on,
         })

--- a/tests/summaryhook_aside/test_block.py
+++ b/tests/summaryhook_aside/test_block.py
@@ -89,14 +89,14 @@ class TestSummaryHookAside(unittest.TestCase):
 
         expected = [{
             'definition_id': 'def-id-01',
-            'type': 'TEXT',
-            'text': 'This is a test',
+            'content_type': 'TEXT',
+            'content_text': 'This is a test',
             'published_on': 'published-on-01',
             'edited_on': 'edited-on-01',
         }, {
             'definition_id': 'def-id-02',
-            'type': 'VIDEO',
-            'text': 'This is the text version from the transcript',
+            'content_type': 'VIDEO',
+            'content_text': 'This is the text version from the transcript',
             'published_on': 'published-on-02',
             'edited_on': 'edited-on-02',
         }]

--- a/tests/summaryhook_aside/test_block.py
+++ b/tests/summaryhook_aside/test_block.py
@@ -89,13 +89,13 @@ class TestSummaryHookAside(unittest.TestCase):
 
         expected = [{
             'definition_id': 'def-id-01',
-            'type': 'html',
+            'type': 'TEXT',
             'text': 'This is a test',
             'published_on': 'published-on-01',
             'edited_on': 'edited-on-01',
         }, {
             'definition_id': 'def-id-02',
-            'type': 'video',
+            'type': 'VIDEO',
             'text': 'This is the text version from the transcript',
             'published_on': 'published-on-02',
             'edited_on': 'edited-on-02',


### PR DESCRIPTION
ai-spot has particular type identifiers it is looking for
and ai-spot uses slightly different field names

with this change and disabled content-length I can pipe through successfully from local devstack to openai via local ai-spot



**Merge checklist:**
Check off if complete *or* not applicable:
- [x] Version bumped
- [x] Changelog record added
- [x] Documentation updated (not only docstrings)
- [x] Fixup commits are squashed away
- [x] Unit tests added/updated
- [x] Manual testing instructions provided
- [x] Noted any: Concerns, dependencies, migration issues, deadlines, tickets
