### PR TITLE
[ACADEMIC-16221] Improved content-length using parsed content

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,7 +14,10 @@ Change Log
 Unreleased
 **********
 
-*
+* [ACADEMIC-16221] Improved content-length using parsed content .
+* [ACADEMIC-16218] Updated permissions so the CI can run properly.
+* [ACADEMIC-16169] [ACADEMIC-16182] Added Unit Tests to block.py.
+* [ACADEMIC-15950] Return proper content for the summary_handler endpoint.
 
 1.2.1 – 2023-05-19
 **********************************************


### PR DESCRIPTION
# [ACADEMIC-16221](https://jira.2u.com/browse/ACADEMIC-16221)

Updated the `summary_handler` endpoint to work as follows:
1. Makes a quick check to see if at least one children is a video or the sum of the raw html content is greater than `SUMMARY_HOOK_MIN_SIZE` setting.
2. If the check fails, returns `{ data: [] }` as response.
3. If it passes, then it processes all its children by parsing their html content or fetching their transcripts in case of a video, and then sums up all the children contents and it's checked against `SUMMARY_HOOK_MIN_SIZE`.
4. If the check fails, returns `{ data: [] }` as response.
5. If it passes, then the parsed content is returned.

The idea behind this is to remove the need for a content-length endpoint from ai-spot and just use this endpoint's response to tell whether if it should allow summarization or not.

If possible, I'd suggest to check on the possibility for the `student_view_aside` endpoint to fetch from a cache enabled `summary_handler` endpoint despite of being in the same module, so the process will only be used once rather than twice (fetch to check to whether render the button or not, and then fetch to summarize).

Minor cleanup on a few lines.