### PR TITLE
fix: content/length structure correct in tests, not tenable in live code

### DIFF
--- a/ai_aside/summaryhook_aside/block.py
+++ b/ai_aside/summaryhook_aside/block.py
@@ -82,13 +82,11 @@ def _extract_child_contents(child, category):
 def _parse_children_contents(block):
     """
     Extracts the analyzable contents from its children.
+    Returns length and an item list
     """
 
     if not _check_summarizable(block):
-        return {
-            'length': 0,
-            'items': []
-        }
+        return 0, []
 
     content_items = []
 
@@ -114,10 +112,7 @@ def _parse_children_contents(block):
             'edited_on': edited_on,
         })
 
-    return {
-        'length': content_length,
-        'items': content_items
-    }
+    return content_length, content_items
 
 
 def _check_summarizable(block):
@@ -177,12 +172,12 @@ class SummaryHookAside(XBlockAside):
 
         data = []
 
-        content = _parse_children_contents(block)
+        length, items = _parse_children_contents(block)
 
-        if content.length < settings.SUMMARY_HOOK_MIN_SIZE or len(content.items) < 1:
+        if length < settings.SUMMARY_HOOK_MIN_SIZE or len(items) < 1:
             return Response(json_body={'data': []})
 
-        for item in content.items:  # pylint: disable=not-an-iterable
+        for item in items:
             data.append({
                 **item,
                 'published_on': _format_date(item['published_on']),
@@ -206,8 +201,8 @@ class SummaryHookAside(XBlockAside):
         fragment = Fragment('')
 
         # Check if there is content that worths summarizing
-        content = _parse_children_contents(block)
-        if content.length < settings.SUMMARY_HOOK_MIN_SIZE:
+        length, _ = _parse_children_contents(block)
+        if length < settings.SUMMARY_HOOK_MIN_SIZE:
             return fragment
 
         # thirdparty=true connects to the unauthenticated handler for now,

--- a/tests/summaryhook_aside/test_block.py
+++ b/tests/summaryhook_aside/test_block.py
@@ -143,9 +143,9 @@ class TestSummaryHookAside(TestCase):
         ]
         block = FakeBlock(children)
 
-        expected = {
-            'length': 289,
-            'items': [{
+        expected_length, expected_items = (
+            289,
+            [{
                 'definition_id': 'def-id-01',
                 'content_type': 'TEXT',
                 'content_text': dedent('''\
@@ -168,11 +168,12 @@ class TestSummaryHookAside(TestCase):
                 'published_on': 'published-on-03',
                 'edited_on': 'edited-on-03',
             }]
-        }
+        )
 
-        content = _parse_children_contents(block)
+        length, items = _parse_children_contents(block)
 
-        self.assertEqual(content, expected)
+        self.assertEqual(length, expected_length)
+        self.assertEqual(items, expected_items)
 
     def test_parse_children_contents_with_valid_children_2(self):
         children = [
@@ -188,9 +189,9 @@ class TestSummaryHookAside(TestCase):
         ]
         block = FakeBlock(children)
 
-        expected = {
-            'length': 19,
-            'items': [{
+        expected_length, expected_items = (
+            19,
+            [{
                 'definition_id': 'def-id-01',
                 'content_type': 'TEXT',
                 'content_text': 'Lorem ipsum.',
@@ -203,11 +204,12 @@ class TestSummaryHookAside(TestCase):
                 'published_on': 'published-on-02',
                 'edited_on': 'edited-on-02',
             }]
-        }
+        )
 
-        content = _parse_children_contents(block)
+        length, items = _parse_children_contents(block)
 
-        self.assertEqual(content, expected)
+        self.assertEqual(length, expected_length)
+        self.assertEqual(items, expected_items)
 
     def test_parse_children_contents_with_invalid_children(self):
         children = [
@@ -216,14 +218,10 @@ class TestSummaryHookAside(TestCase):
         ]
         block = FakeBlock(children)
 
-        expected = {
-            'length': 0,
-            'items': []
-        }
+        length, items = _parse_children_contents(block)
 
-        content = _parse_children_contents(block)
-
-        self.assertEqual(content, expected)
+        self.assertEqual(length, 0)
+        self.assertEqual(items, [])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
could have correctly referenced the dict object but it's more pythonic to just return two things

**Merge checklist:**
Check off if complete *or* not applicable:
- [x] Version bumped
- [x] Changelog record added
- [x] Documentation updated (not only docstrings)
- [x] Fixup commits are squashed away
- [x] Unit tests added/updated
- [x] Manual testing instructions provided
- [x] Noted any: Concerns, dependencies, migration issues, deadlines, tickets
