### PR TITLE
[ACADEMIC-16262] Updated HTML parser to remove unwanted tag contents.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,15 @@ Change Log
 Unreleased
 **********
 
+2.0.2 – 2023-07-05
+**********************************************
+
+Fix
+=====
+
+* Updated HTML parser to remove tags with their content for specific cases like `<script>` or `<style>`.
+
+
 2.0.1 – 2023-06-29
 **********************************************
 

--- a/ai_aside/__init__.py
+++ b/ai_aside/__init__.py
@@ -2,4 +2,4 @@
 A plugin containing xblocks and apps supporting GPT and other LLM use on edX.
 """
 
-__version__ = '2.0.1'
+__version__ = '2.0.2'

--- a/ai_aside/summaryhook_aside/settings/common.py
+++ b/ai_aside/summaryhook_aside/settings/common.py
@@ -9,3 +9,4 @@ def plugin_settings(settings):
     settings.SUMMARY_HOOK_HOST = env_tokens.get('SUMMARY_HOOK_HOST', '')
     settings.SUMMARY_HOOK_JS_PATH = env_tokens.get('SUMMARY_HOOK_JS_PATH', '')
     settings.AISPOT_LMS_NAME = env_tokens.get('AISPOT_LMS_NAME', '')
+    settings.HTML_TAGS_TO_REMOVE = ['script', 'style']


### PR DESCRIPTION
# [ACADEMIC-16262](https://jira.2u.com/browse/ACADEMIC-16262)

While the `summary_handler` endpoint was removing the html tags, it was not ignoring the contents for non-content embed tags, like `<script>` or `<style>`. This update makes the parser ignore the tags and its contents from the end result.

**Merge checklist:**
Check off if complete *or* not applicable:
- [x] Version bumped
- [x] Changelog record added
- [x] Documentation updated (not only docstrings)
- [x] Fixup commits are squashed away
- [x] Unit tests added/updated
- [x] Manual testing instructions provided
- [x] Noted any: Concerns, dependencies, migration issues, deadlines, tickets
