### PR TITLE
exception sponge

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,10 +14,9 @@ Change Log
 Unreleased
 **********
 
-Fix
-=====
-
 feat: [ACADEMIC-16207] Added models to summaryhook_aside (Has migrations)
+
+feat: [ACADEMIC-16177] Catch exceptions in a couple of locations so the aside cannot crash content.
 
 2.0.2 – 2023-07-05
 **********************************************

--- a/ai_aside/block.py
+++ b/ai_aside/block.py
@@ -2,6 +2,7 @@
 
 """Xblock aside enabling OpenAI driven summaries."""
 
+import logging
 from datetime import datetime
 
 from django.conf import settings
@@ -12,6 +13,8 @@ from xblock.core import XBlock, XBlockAside
 
 from ai_aside.text_utils import html_to_text
 from ai_aside.waffle import summary_enabled, summary_staff_only
+
+log = logging.getLogger(__name__)
 
 # map block types to what ai-spot expects for content types
 CATEGORY_TYPE_MAP = {
@@ -189,7 +192,28 @@ class SummaryHookAside(XBlockAside):
 
     @XBlockAside.aside_for('student_view')
     def student_view_aside(self, block, context=None):  # pylint: disable=unused-argument
-        """Render the aside contents for the student view."""
+        """
+        Render the aside contents for the student view.
+
+        Returns a Fragment.
+
+        This function absorbs all exceptions to protect the LMS,
+        delegating real work to _student_view_can_throw
+        """
+        try:
+            return self._student_view_can_throw(block)
+        except Exception as ex:  # pylint: disable=broad-exception-caught
+            log.error(f'Summary hook aside suppressed exception during student_view_aside: {ex}')
+            return Fragment('')
+
+    def _student_view_can_throw(self, block):
+        """
+        Render the aside contents for the student view.
+
+        Returns a Fragment.
+
+        This function can throw exceptions.
+        """
         fragment = Fragment('')
 
         # Check if there is content that worths summarizing
@@ -221,7 +245,25 @@ class SummaryHookAside(XBlockAside):
 
     @classmethod
     def should_apply_to_block(cls, block):
-        """Determine whether this aside should apply to a given block type, course, and user."""
+        """
+        Determine whether this aside should apply to a given block type, course, and user.
+
+        This function absorbs all exceptions to protect the LMS,
+        delegating real work to _should_apply_throws.
+        """
+        try:
+            return cls._should_apply_can_throw(block)
+        except Exception as ex:  # pylint: disable=broad-exception-caught
+            log.error(f'Summary hook aside suppressed exception during should_apply_to_block: {ex}')
+            return False
+
+    @classmethod
+    def _should_apply_can_throw(cls, block):
+        """
+        Determine whether this aside should apply to a given block type, course, and user.
+
+        This function can throw exceptions.
+        """
         if getattr(block, 'category', None) != 'vertical':
             return False
         course_key = block.scope_ids.usage_id.course_key

--- a/ai_aside/block.py
+++ b/ai_aside/block.py
@@ -55,27 +55,18 @@ def _extract_child_contents(child, category):
 
     Returns a string.
     """
-    try:
-        # pylint: disable=import-outside-toplevel
-        from xmodule.video_block.transcripts_utils import get_transcript
-    except ImportError:
-        return None
+    # pylint: disable=import-outside-toplevel
+    from xmodule.video_block.transcripts_utils import get_transcript
 
     if category == 'html':
-        try:
-            content_html = child.get_html()
-            text = html_to_text(content_html)
+        content_html = child.get_html()
+        text = html_to_text(content_html)
 
-            return text
-        except AttributeError:
-            return None
+        return text
 
     if category == 'video':
-        try:
-            transcript, _, _ = get_transcript(child, output_format='txt')
-            return transcript
-        except AttributeError:
-            return None
+        transcript, _, _ = get_transcript(child, output_format='txt')
+        return transcript
 
     return None
 
@@ -127,18 +118,14 @@ def _check_summarizable(block):
     content_length = 0
 
     for child in children:
-        try:
-            category = child.category
-            if category == 'html':
-                content_length += len(child.get_html())
-                if content_length > settings.SUMMARY_HOOK_MIN_SIZE:
-                    return True
-
-            if category == 'video':
+        category = child.category
+        if category == 'html':
+            content_length += len(child.get_html())
+            if content_length > settings.SUMMARY_HOOK_MIN_SIZE:
                 return True
 
-        except AttributeError:
-            pass
+        if category == 'video':
+            return True
 
     return False
 

--- a/ai_aside/platform_imports.py
+++ b/ai_aside/platform_imports.py
@@ -1,0 +1,23 @@
+# pyright: reportMissingImports=false
+
+"""
+Contain all imported functions coming out of the platform.
+
+We know these functions will be available at run time, but they
+cannot be imported normally.
+"""
+
+
+def get_text_transcript(video_block):
+    """Get the transcript for a video block in text format."""
+    # pylint: disable=import-error, import-outside-toplevel
+    from xmodule.video_block.transcripts_utils import get_transcript
+    transcript, _, _ = get_transcript(video_block, output_format='txt')
+    return transcript
+
+
+def get_block(usage_key):
+    """Get a block from the module store given the usage key."""
+    # pylint: disable=import-error, import-outside-toplevel
+    from xmodule.modulestore.django import modulestore
+    return modulestore().get_item(usage_key)


### PR DESCRIPTION
First commit: In order to alert on errors, first force them all to be very similar. This also prevents the aside from crashing course content rendering.

Second commit cleans out a few extra exception catches we don't really expect to trigger, they can end up in the sponge.

Third commit is just some import cleanliness.

Tested locally in normal operation and by forcing an exception to soak.

**Merge checklist:**
Check off if complete *or* not applicable:
- [x] Version bumped
- [x] Changelog record added
- [x] Documentation updated (not only docstrings)
- [x] Fixup commits are squashed away
- [x] Unit tests added/updated
- [x] Manual testing instructions provided
- [x] Noted any: Concerns, dependencies, migration issues, deadlines, tickets
