### PR TITLE
feat: add log line to positive case

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,10 @@ Change Log
 Unreleased
 **********
 
+3.0.1 – 2023-07-20
+**********************************************
+
+* Add positive log when summary fragement decides to inject
 
 3.0.0 – 2023-07-16
 **********************************************

--- a/ai_aside/__init__.py
+++ b/ai_aside/__init__.py
@@ -2,4 +2,4 @@
 A plugin containing xblocks and apps supporting GPT and other LLM use on edX.
 """
 
-__version__ = '3.0.0'
+__version__ = '3.0.1'

--- a/ai_aside/block.py
+++ b/ai_aside/block.py
@@ -209,14 +209,18 @@ class SummaryHookAside(XBlockAside):
         if length < settings.SUMMARY_HOOK_MIN_SIZE:
             return fragment
 
+        usage_id = block.scope_ids.usage_id
+
+        log.info(f'Summary hook injecting into {usage_id}')
+
         handler_url = self._summary_handler_url()
 
         fragment.add_content(
             _render_summary(
                 {
                     'data_url_api': settings.SUMMARY_HOOK_HOST,
-                    'data_course_id': block.scope_ids.usage_id.course_key,
-                    'data_content_id': block.scope_ids.usage_id,
+                    'data_course_id': usage_id.course_key,
+                    'data_content_id': usage_id,
                     'data_handler_url': handler_url,
                     'js_url': settings.SUMMARY_HOOK_HOST + settings.SUMMARY_HOOK_JS_PATH,
                 }


### PR DESCRIPTION
thought of this when I was working out how we should alert - I don't think we actually need this for alerting but it is useful for debugging

sample line

`2023-07-20 13:21:59,530 INFO 118 [ai_aside.block] [user 3] [ip 172.19.0.1] block.py:214 - Summary hook injecting into block-v1:edX+DemoX+Demo_Course+type@vertical+block@vertical_2dbb0072785e`

**Merge checklist:**
Check off if complete *or* not applicable:
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Fixup commits are squashed away
- [ ] Unit tests added/updated
- [ ] Manual testing instructions provided
- [ ] Noted any: Concerns, dependencies, migration issues, deadlines, tickets
