### PR TITLE
catch transcript errors, report block ID with error

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,9 @@ Change Log
 Unreleased
 **********
 
+* Error suppression logs now include block ID
+* Missing video transcript is caught earlier in content fetch
+
 3.1.0 – 2023-07-20
 **********************************************
 

--- a/ai_aside/block.py
+++ b/ai_aside/block.py
@@ -56,7 +56,7 @@ def _extract_child_contents(child, category):
     """
     Process the child contents based on its category.
 
-    Returns a string.
+    Returns a string or None if there are no contents available.
     """
     if category == 'html':
         content_html = child.get_html()
@@ -65,7 +65,7 @@ def _extract_child_contents(child, category):
         return text
 
     if category == 'video':
-        transcript = get_text_transcript(child)
+        transcript = get_text_transcript(child)  # may be None
         return transcript
 
     return None
@@ -191,7 +191,8 @@ class SummaryHookAside(XBlockAside):
         try:
             return self._student_view_can_throw(block)
         except Exception as ex:  # pylint: disable=broad-exception-caught
-            log.error(f'Summary hook aside suppressed exception during student_view_aside: {ex}')
+            usage_id = block.scope_ids.usage_id
+            log.error(f'Summary hook aside suppressed exception on {usage_id} during student_view_aside: {ex}')
             return Fragment('')
 
     def _student_view_can_throw(self, block):
@@ -257,7 +258,8 @@ class SummaryHookAside(XBlockAside):
         try:
             return cls._should_apply_can_throw(block)
         except Exception as ex:  # pylint: disable=broad-exception-caught
-            log.error(f'Summary hook aside suppressed exception during should_apply_to_block: {ex}')
+            usage_id = block.scope_ids.usage_id
+            log.error(f'Summary hook aside suppressed exception on {usage_id} during should_apply_to_block: {ex}')
             return False
 
     @classmethod

--- a/ai_aside/platform_imports.py
+++ b/ai_aside/platform_imports.py
@@ -9,10 +9,15 @@ cannot be imported normally.
 
 
 def get_text_transcript(video_block):
-    """Get the transcript for a video block in text format."""
+    """Get the transcript for a video block in text format, or None."""
     # pylint: disable=import-error, import-outside-toplevel
+    from xmodule.exceptions import NotFoundError
     from xmodule.video_block.transcripts_utils import get_transcript
-    transcript, _, _ = get_transcript(video_block, output_format='txt')
+    try:
+        transcript, _, _ = get_transcript(video_block, output_format='txt')
+    except NotFoundError:
+        # some old videos have no transcripts, just accept that reality
+        return None
     return transcript
 
 


### PR DESCRIPTION
found by inspecting newrelic logs - we are in fact already suppressing errors, but they are boring ones we would prefer not to even log about and we'd like a bit more info when we suppress stuff

locally tested to make sure it still works and by forcing a fake error to see the improved log


**Merge checklist:**
Check off if complete *or* not applicable:
- [x] Version bumped
- [x] Changelog record added
- [x] Documentation updated (not only docstrings)
- [x] Fixup commits are squashed away
- [x] Unit tests added/updated
- [x] Manual testing instructions provided
- [x] Noted any: Concerns, dependencies, migration issues, deadlines, tickets
