### PR TITLE
fix: move standard error handling to where it will not bother newrelic

### DIFF
--- a/ai_aside/__init__.py
+++ b/ai_aside/__init__.py
@@ -2,6 +2,6 @@
 A plugin containing xblocks and apps supporting GPT and other LLM use on edX.
 """
 
-__version__ = '3.6.2'
+__version__ = '3.7.0'
 
 default_app_config = "ai_aside.apps.AiAsideConfig"

--- a/ai_aside/config_api/views.py
+++ b/ai_aside/config_api/views.py
@@ -27,13 +27,14 @@ from ai_aside.config_api.api import (
 )
 from ai_aside.config_api.exceptions import AiAsideException, AiAsideNotFoundException
 from ai_aside.config_api.validators import validate_course_key, validate_unit_key
-from ai_aside.config_api.view_utils import AiAsideAPIView, APIResponse
+from ai_aside.config_api.view_utils import AiAsideAPIView, APIResponse, handle_errors
 
 
 class CourseSummaryConfigEnabledAPIView(AiAsideAPIView):
     """
     Simple GET endpoint to expose whether the course may use summary config.
     """
+    @handle_errors
     def get(self, request, course_id=None):
         """Expose whether the course may use summary config"""
         if course_id is None:
@@ -46,6 +47,7 @@ class CourseSummaryConfigEnabledAPIView(AiAsideAPIView):
 
 class CourseEnabledAPIView(AiAsideAPIView):
     """Handlers for course level settings"""
+    @handle_errors
     def get(self, request, course_id=None):
         """Gets the enabled state for a course"""
         if course_id is None:
@@ -55,6 +57,7 @@ class CourseEnabledAPIView(AiAsideAPIView):
         settings = get_course_settings(course_key)
         return APIResponse(success=True, data=settings)
 
+    @handle_errors
     def post(self, request, course_id=None):
         """Update the course and reset if its necessary"""
 
@@ -74,6 +77,7 @@ class CourseEnabledAPIView(AiAsideAPIView):
 
         return APIResponse(success=True)
 
+    @handle_errors
     def delete(self, request, course_id=None):
         """Deletes the settings for a module"""
 
@@ -87,6 +91,7 @@ class CourseEnabledAPIView(AiAsideAPIView):
 
 class UnitEnabledAPIView(AiAsideAPIView):
     """Handlers for module level settings"""
+    @handle_errors
     def get(self, request, course_id=None, unit_id=None):
         """Gets the enabled state for a unit"""
         if course_id is None or unit_id is None:
@@ -97,6 +102,7 @@ class UnitEnabledAPIView(AiAsideAPIView):
         settings = get_unit_settings(course_key, unit_key)
         return APIResponse(success=True, data=settings)
 
+    @handle_errors
     def post(self, request, course_id=None, unit_id=None):
         """Sets the enabled state for a unit"""
 
@@ -111,6 +117,7 @@ class UnitEnabledAPIView(AiAsideAPIView):
 
         return APIResponse(success=True)
 
+    @handle_errors
     def delete(self, request, course_id=None, unit_id=None):
         """Deletes the settings for a unit"""
 


### PR DESCRIPTION
newrelic injects itself around the standard handlers, before handle_exception, so we need our non-freak-out exceptions handled before newrelic can see it and freak out

this is covered in unit tests, also tested locally by removing settings and seeing the expected 404 capture

3.7.0 will be automatically picked up on stage, prod will require an edx-internal change
