### PR TITLE
feat: Added setting to set the default enabled state for course summaries

### DIFF
--- a/ai_aside/config_api/api.py
+++ b/ai_aside/config_api/api.py
@@ -1,6 +1,8 @@
 """
 Implements an API for updating unit and course settings.
 """
+from django.conf import settings as django_settings
+
 from ai_aside.config_api.exceptions import AiAsideNotFoundException
 from ai_aside.config_api.internal import _get_course, _get_course_units, _get_unit
 from ai_aside.models import AIAsideCourseEnabled, AIAsideUnitEnabled
@@ -142,6 +144,8 @@ def is_summary_enabled(course_key, unit_key=None):
     if not summaries_configuration_enabled(course_key):
         return False
 
+    enabled_by_default = django_settings.SUMMARY_ENABLED_BY_DEFAULT is True
+
     if unit_key is not None:
         try:
             unit = _get_unit(course_key, unit_key)
@@ -154,9 +158,9 @@ def is_summary_enabled(course_key, unit_key=None):
     try:
         course = _get_course(course_key)
     except AiAsideNotFoundException:
-        return False
+        return enabled_by_default
 
     if course is not None:
         return course.enabled
 
-    return False
+    return enabled_by_default

--- a/ai_aside/settings/devstack.py
+++ b/ai_aside/settings/devstack.py
@@ -9,6 +9,7 @@ def plugin_settings(settings):
     settings.SUMMARY_HOOK_HOST = 'http://ai-spot.2u.localhost'
     settings.SUMMARY_HOOK_JS_PATH = '/static/js/main.js'
     settings.SUMMARY_HOOK_MIN_SIZE = 500
+    settings.SUMMARY_ENABLED_BY_DEFAULT = False
     settings.AISPOT_LMS_NAME = 'lms'  # in docker ai-spot sees the LMS as 'lms' not 'localhost'
     if os.path.isfile(join(dirname(abspath(__file__)), 'private.py')):
         from .private import plugin_settings_override  # pylint: disable=import-outside-toplevel,import-error


### PR DESCRIPTION
Currently, the course summary is disabled by default. It needs to explicitly be enabled on the course configuration.

These changes allow to set the default enabled state by a setting. This does not overrides the waffle flag, meaning that even if the setting is set to be enabled by default, it can still be disabled by the course waffle flag, which takes priority.

**Merge checklist:**
Check off if complete *or* not applicable:
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Fixup commits are squashed away
- [ ] Unit tests added/updated
- [ ] Manual testing instructions provided
- [ ] Noted any: Concerns, dependencies, migration issues, deadlines, tickets
