### PR TITLE
fix: add missing class variables to AiAsideCourseApp

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,10 @@ Change Log
 Unreleased
 **********
 
+3.8.2 - 2025-05-14
+**********************************************
+* Fixed bug where necessary class variables were not set on the AiAsideCourseApp class
+
 3.8.1 - 2025-05-13
 **********************************************
 * Bumped ubuntu version to latest for the PyPi publishing job

--- a/ai_aside/__init__.py
+++ b/ai_aside/__init__.py
@@ -2,6 +2,6 @@
 A plugin containing xblocks and apps supporting GPT and other LLM use on edX.
 """
 
-__version__ = '3.8.1'
+__version__ = '3.8.2'
 
 default_app_config = "ai_aside.apps.AiAsideConfig"

--- a/ai_aside/plugins.py
+++ b/ai_aside/plugins.py
@@ -15,6 +15,14 @@ class AiAsideCourseApp(CourseApp):
     Please see the associated ADR for more details.
     """
 
+    app_id = 'xpert-unit-summary'
+    name = 'Xpert unit summaries'
+    description = 'Use generative AI to summarize course content and reinforce learning.'
+    documentation_links = {
+        'learn_more_openai': 'https://openai.com/',
+        'learn_more_openai_data_privacy': 'https://openai.com/api-data-privacy',
+    }
+
     @classmethod
     def is_available(cls, course_key):  # pylint: disable=unused-argument
         """


### PR DESCRIPTION
### Description

This PR adds missing class variables to the `AiAsideCourseApp` class. These variables are used by the [CourseAppSerializer](https://github.com/openedx/edx-platform/blob/db49b2d0a379e0aa9e75b7f8ac2af0cd717a1619/openedx/core/djangoapps/course_apps/rest_api/v1/views.py#L43). If they are not defined, an error is raised, which results in the course apps view returning a 500. The impact is that all course apps but the Xpert unit summaries are missing on the page.

**Merge checklist:**
Check off if complete *or* not applicable:
- [x] Version bumped
- [x] Changelog record added
- [x] Documentation updated (not only docstrings)
- [x] Fixup commits are squashed away
- [x] Unit tests added/updated
- [x] Manual testing instructions provided
- [x] Noted any: Concerns, dependencies, migration issues, deadlines, tickets
