### PR TITLE
chore: correct app_id for course_app/plugin for unit summaries

### DIFF
--- a/ai_aside/plugins.py
+++ b/ai_aside/plugins.py
@@ -15,7 +15,7 @@ class AiAsideCourseApp(CourseApp):
     Please see the associated ADR for more details.
     """
 
-    app_id = 'xpert-unit-summary'
+    app_id = 'xpert_unit_summary'
     name = 'Xpert unit summaries'
     description = 'Use generative AI to summarize course content and reinforce learning.'
     documentation_links = {


### PR DESCRIPTION
Fix for: https://2u-internal.atlassian.net/browse/COSMO-608

This fixes the implementation for https://github.com/edx/ai-aside/pull/150, and will allow xpert_unit_summary to be detected as a plugin by `edx-platform` and thereby `frontend-app-authoring` via the Pages & Resources page.