### PR TITLE
fix: resolve issue with Xpert unit summary toggle not updating state

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,11 @@ Change Log
 Unreleased
 **********
 
+3.8.6 - 2026-03-24
+**********************************************
+* Fixed is_summary_enabled() to properly check course-level settings when no unit record exists
+* This ensures course-level toggle correctly controls summary button visibility
+
 3.8.5 - 2026-02-10
 **********************************************
 * Added client ID support for unit summary feature

--- a/ai_aside/__init__.py
+++ b/ai_aside/__init__.py
@@ -2,6 +2,6 @@
 A plugin containing xblocks and apps supporting GPT and other LLM use on edX.
 """
 
-__version__ = '3.8.5'
+__version__ = '3.8.6'
 
 default_app_config = "ai_aside.apps.AiAsideConfig"

--- a/ai_aside/config_api/api.py
+++ b/ai_aside/config_api/api.py
@@ -146,21 +146,23 @@ def is_summary_enabled(course_key, unit_key=None):
 
     enabled_by_default = django_settings.SUMMARY_ENABLED_BY_DEFAULT is True
 
+    # Check unit-level override if unit_key provided
     if unit_key is not None:
         try:
             unit = _get_unit(course_key, unit_key)
-
             if unit is not None:
                 return unit.enabled
         except AiAsideNotFoundException:
-            return enabled_by_default
+            # No unit-level setting, fall through to check course-level
+            pass
 
+    # Check course-level setting
     try:
         course = _get_course(course_key)
+        if course is not None:
+            return course.enabled
     except AiAsideNotFoundException:
-        return enabled_by_default
-
-    if course is not None:
-        return course.enabled
+        # No course-level setting, use default
+        pass
 
     return enabled_by_default

--- a/tests/api/test_api.py
+++ b/tests/api/test_api.py
@@ -289,7 +289,7 @@ class TestApiMethods(TestCase):
             enabled=False,
         )
 
-        self.assertFalse(is_summary_enabled(course_key_true, unit_key_non_existent))
+        self.assertTrue(is_summary_enabled(course_key_true, unit_key_non_existent))
         self.assertFalse(is_summary_enabled(course_key_false, unit_key_non_existent))
         self.assertFalse(is_summary_enabled(course_key_non_existent, unit_key_non_existent))
 
@@ -337,7 +337,7 @@ class TestApiMethods(TestCase):
         self.assertTrue(is_summary_enabled(course_key_true))
         self.assertFalse(is_summary_enabled(course_key_false))
         self.assertTrue(is_summary_enabled(course_key_true, unit_key_non_existent))
-        self.assertTrue(is_summary_enabled(course_key_false, unit_key_non_existent))
+        self.assertFalse(is_summary_enabled(course_key_false, unit_key_non_existent))
         self.assertTrue(is_summary_enabled(course_key_non_existent, unit_key_non_existent))
 
     def test_reset_course_unit_settings(self):


### PR DESCRIPTION
## Description

 Xpert Unit Summary toggle in Pages & Resources doesn't toggle between enable/disable . 
 
 ### Cause
 
DoesNotExist exception returns enabled_by_default instead of falling through to check course-level enabled setting.

### Ticket

[COSMO2-841](https://2u-internal.atlassian.net/browse/COSMO2-841)

**Merge checklist:**
Check off if complete *or* not applicable:
- [x] Version bumped
- [x] Changelog record added
- [x] Documentation updated (not only docstrings)
- [x] Fixup commits are squashed away
- [x] Unit tests added/updated
- [x] Manual testing instructions provided
- [x] Noted any: Concerns, dependencies, migration issues, deadlines, tickets
