### PR TITLE
fix: Enable Django 4.2 and 5.2 testing on Python 3.11

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,12 +13,12 @@ jobs:
       contents: read
     strategy:
       matrix:
-        tox-env: [django32, quality]
+        tox-env: [py311-django42, py311-django52, quality]
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.8'
+          python-version: '3.11'
           architecture: x64
       - name: Install requirements
         run: pip install -r requirements/ci.txt

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,10 @@ Change Log
 Unreleased
 **********
 
+3.8.8 - 2026-08-05
+**********************************************
+* Added Django 5.2 tox/CI compatibility and Python 3.11 test matrix updates.
+
 3.8.7 - 2026-07-28
 **********************************************
 * Gave the Xpert Unit Summary button and panel a light note-box look, scoped to

--- a/ai_aside/__init__.py
+++ b/ai_aside/__init__.py
@@ -2,6 +2,6 @@
 A plugin containing xblocks and apps supporting GPT and other LLM use on edX.
 """
 
-__version__ = '3.8.7'
+__version__ = '3.8.8'
 
 default_app_config = "ai_aside.apps.AiAsideConfig"

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -8,7 +8,7 @@ appdirs==1.4.4
     # via
     #   -r requirements/base.txt
     #   fs
-asgiref==3.7.2
+asgiref==3.8.1
     # via
     #   -r requirements/base.txt
     #   django

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py38-django{32,40}
+envlist = py311-django{42,52}
 
 [doc8]
 ; D001 = Line too long
@@ -35,9 +35,11 @@ addopts = --cov ai_aside --cov-report term-missing --cov-report xml
 norecursedirs = .* docs requirements site-packages
 
 [testenv]
+basepython = python3.11
 deps =
-    django32: Django>=3.2,<4.0
-    django40: Django>=4.0,<4.1
+    setuptools<81
+    django42: Django>=4.2,<4.3
+    django52: Django>=5.2,<5.3
     -r{toxinidir}/requirements/test.txt
 commands =
     pytest {posargs}


### PR DESCRIPTION
### Description:
Updated ai-aside test setup so CI and tox run against both Django 4.2 and Django 5.2 using Python 3.11.

### Solution:

- Updated tox matrix to run py311-django42 and py311-django52.
- Scoped Python 3.11 to those Django test environments.
- Updated CI workflow matrix to run py311-django42, py311-django52, and quality on Python 3.11.
- Fixed dependency issues so Django 5.2 resolves and tests run cleanly.

     - Added a setuptools<81 constraint in tox test dependencies because xblock still imports pkg_resources, which is unavailable with newer setuptools in this environment.
     - Updated asgiref from 3.7.2 to 3.8.1 in test requirements to satisfy Django 5.2 minimum dependency constraints.

### Private JIRA Link:
[BOMS-407](https://2u-internal.atlassian.net/browse/BOMS-407)